### PR TITLE
Fix the composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "psr7-sessions/session-encode-decoder",
+    "name":        "psr7-sessions/session-encode-decode",
     "description": "Storageless PSR-7 Session support",
     "license":     "MIT",
     "authors": [


### PR DESCRIPTION
Currently, you must specify the source of the package when attempting to add this to your project's composer.json, as the package name doesn't match the GitHub project name.

This resolves the issue by dropping the `r` from the composer.json name.