### PR TITLE
Add php-7.2 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.1
+  - 7.2
 
 before_script:
   - composer update --prefer-source --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php":  "~7.0"
+        "php":  "~7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^7"
     },
     "autoload": {
         "psr-4": {

--- a/test/unit/DecodeTest.php
+++ b/test/unit/DecodeTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PSR7SessionEncodeDecodeTest;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PSR7SessionEncodeDecode\Decoder;
 
 /**
  * @covers \PSR7SessionEncodeDecode\Decoder
  */
-class DecodeTest extends PHPUnit_Framework_TestCase
+class DecodeTest extends TestCase
 {
     /**
      * @var Decoder

--- a/test/unit/EncoderTest.php
+++ b/test/unit/EncoderTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PSR7SessionEncodeDecodeTest;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PSR7SessionEncodeDecode\Encoder;
 
 /**
  * @covers \PSR7SessionEncodeDecode\Encoder
  */
-class EncoderTest extends PHPUnit_Framework_TestCase
+class EncoderTest extends TestCase
 {
     /**
      * @var Encoder


### PR DESCRIPTION
# Changed log
- Add `php-7.2` test in Travis CI build.
- Change into `>=7.1` inside `require` block in `composer.json`.
- Upgrade the PHPUnit version to be `^6.5`.
- Using the class-based PHPUnit namespace to be compatible with the latest PHPUnit version.